### PR TITLE
add more error handlers

### DIFF
--- a/hpnl.conf
+++ b/hpnl.conf
@@ -1,1 +1,0 @@
-worker_num = 1

--- a/include/HPNL/CQExternalDemultiplexer.h
+++ b/include/HPNL/CQExternalDemultiplexer.h
@@ -6,18 +6,21 @@
 
 #include "HPNL/FIStack.h"
 #include "HPNL/FIConnection.h"
+#include "HPNL/Common.h"
 
 class CQExternalDemultiplexer {
   public:
     CQExternalDemultiplexer(FIStack*, fid_cq*);
     ~CQExternalDemultiplexer();
+    int init();
     int wait_event(fid_eq**, int*, int*);
   private:
+    FIStack *stack;
+    fid_cq *cq;
     fid_fabric *fabric;
     struct epoll_event event;
     int epfd;
     int fd;
-    fid_cq *cq;
     uint64_t start;
     uint64_t end;
 };

--- a/include/HPNL/Common.h
+++ b/include/HPNL/Common.h
@@ -5,4 +5,12 @@
 #define MEM_SIZE 65536
 #define MAX_WORKERS 10
 
+#include <system_error>
+
+inline void throw_system_error(bool condition, const char* what) {
+  if (condition) {
+    throw std::system_error(errno, std::system_category(), what);
+  }
+}
+
 #endif

--- a/include/HPNL/Connection.h
+++ b/include/HPNL/Connection.h
@@ -5,13 +5,14 @@
 
 class Connection {
   public:
+    virtual int init() { return 0; }
     virtual void recv(char*, int) {}
-    virtual void send(const char*, int, int, int, long) {}
-    virtual void send(int, int) {}
-    virtual int read(int, int, uint64_t, uint64_t, uint64_t) {}
-    virtual void shutdown() {}
+    virtual int send(const char*, int, int, int, long) { return 0; }
+    virtual int send(int, int) { return 0; }
+    virtual int read(int, int, uint64_t, uint64_t, uint64_t) { return 0; }
+    virtual void shutdown() { }
     virtual void take_back_chunk(Chunk*) {}
-    virtual void activate_chunk(Chunk*) {}
+    virtual int activate_chunk(Chunk*) { return 0; }
 };
 
 #endif

--- a/include/HPNL/EQExternalDemultiplexer.h
+++ b/include/HPNL/EQExternalDemultiplexer.h
@@ -8,11 +8,13 @@
 
 #include "HPNL/FIStack.h"
 #include "HPNL/FIConnection.h"
+#include "HPNL/Common.h"
 
 class EQExternalDemultiplexer {
   public:
     EQExternalDemultiplexer(FIStack*);
     ~EQExternalDemultiplexer();
+    int init();
     int wait_event(fi_info**, fid_eq**);
     int add_event(fid_eq*);
     int delete_event(fid_eq*);

--- a/include/HPNL/ExternalEqService.h
+++ b/include/HPNL/ExternalEqService.h
@@ -13,6 +13,7 @@ class ExternalEqService {
   public:
     ExternalEqService(const char*, const char*, int, int, bool is_server_ = false);
     ~ExternalEqService();
+    int init();
     fid_eq* connect();
     fid_eq* accept(fi_info*);
     uint64_t reg_rma_buffer(char*, uint64_t, int);
@@ -33,11 +34,10 @@ class ExternalEqService {
   private:
     FIStack *stack;
 
-    int worker_num;
-    int buffer_num;
-
     const char* ip;
     const char* port;
+    int worker_num;
+    int buffer_num;
     bool is_server;
 
     char *recvBuffer;

--- a/include/HPNL/FIConnection.h
+++ b/include/HPNL/FIConnection.h
@@ -37,16 +37,17 @@ class FIConnection : public Connection {
     FIConnection(FIStack*, fid_fabric*, fi_info*, fid_domain*, fid_cq*, fid_wait*, BufMgr*, BufMgr*, bool, int buffer_num);
     ~FIConnection();
 
+    virtual int init() override;
     virtual void recv(char*, int) override;
-    virtual void send(const char*, int, int, int, long) override;
-    virtual void send(int, int) override;
+    virtual int send(const char*, int, int, int, long) override;
+    virtual int send(int, int) override;
     virtual int read(int, int, uint64_t, uint64_t, uint64_t) override;
     virtual void shutdown() override;
     virtual void take_back_chunk(Chunk*) override;
-    virtual void activate_chunk(Chunk*) override;
+    virtual int activate_chunk(Chunk*) override;
     
-    void connect();
-    void accept();
+    int connect();
+    int accept();
 
     void init_addr();
     void get_addr(char**, size_t*, char**, size_t*);
@@ -71,7 +72,7 @@ class FIConnection : public Connection {
     
   private:
     FIStack *stack;
-
+    fid_fabric *fabric;
     fi_info *info;
     fid_domain *domain;
     fid_ep *ep;
@@ -90,7 +91,9 @@ class FIConnection : public Connection {
 
     fid_wait *waitset;
 
-    bool server;
+    bool is_server;
+
+    int buffer_num;
 
     size_t dest_port;
     char *dest_addr;

--- a/include/HPNL/FIStack.h
+++ b/include/HPNL/FIStack.h
@@ -12,6 +12,7 @@
 #include "HPNL/FIConnection.h"
 #include "HPNL/ConMgr.h"
 #include "HPNL/Handle.h"
+#include "HPNL/Common.h"
 
 #define MAX_WORKER_NUM 10
 
@@ -19,8 +20,9 @@ class FIStack {
   public:
     FIStack(const char*, const char*, uint64_t, int, int);
     ~FIStack();
+    int init();
     HandlePtr bind();
-    void listen();
+    int listen();
     HandlePtr connect(BufMgr*, BufMgr*);
     HandlePtr accept(void*, BufMgr*, BufMgr*);
     uint64_t reg_rma_buffer(char*, uint64_t, int);
@@ -33,9 +35,12 @@ class FIStack {
     fid_cq** get_cqs();
 
   private:
-    uint64_t seq_num;
+    const char *ip;
+    const char *port;
+    uint64_t flags;
     int worker_num;
     int buffer_num;
+    uint64_t seq_num;
     int total_buffer_num;
     fid_fabric *fabric;
     fid_domain *domain;

--- a/java/hpnl/src/main/java/com/intel/hpnl/core/Connection.java
+++ b/java/hpnl/src/main/java/com/intel/hpnl/core/Connection.java
@@ -31,7 +31,7 @@ public class Connection {
   }
 
   public native void recv(ByteBuffer buffer, int id);
-  public native void send(int blockBufferSize, int rdmaBufferId);
+  public native int send(int blockBufferSize, int rdmaBufferId);
   public native int read(int rdmaBufferId, int localOffset, long len, long remoteAddr, long remoteMr);
   private native void init(long eq);
   public native void finalize();

--- a/java/hpnl/src/main/java/com/intel/hpnl/core/CqService.java
+++ b/java/hpnl/src/main/java/com/intel/hpnl/core/CqService.java
@@ -13,14 +13,17 @@ public class CqService {
     this.serviceNativeHandle = serviceNativeHandle;
 
     //Runtime.getRuntime().addShutdownHook(new CqShutdownThread(eqService, this));
-
     this.cqThreads = new ArrayList<CqThread>();
     this.externalHandlers = new ArrayList<ExternalHandler>();
   }
 
-  public void start() {
-    init(serviceNativeHandle);
-    
+  public CqService init() {
+    if (init(serviceNativeHandle) == -1)
+      return null;
+    return this;
+  }
+
+  public int start() {
     int workerNum = this.eqService.getWorkerNum();
     for (int i = 0; i < workerNum; i++) {
       CqThread cqThread = new CqThread(this, i);
@@ -29,6 +32,7 @@ public class CqService {
     for (CqThread cqThread : cqThreads) {
       cqThread.start();
     }
+    return 0;
   }
 
   public void shutdown() {
@@ -72,13 +76,15 @@ public class CqService {
   }
 
   public int wait_event(int index) {
-    wait_cq_event(index);
+    if (wait_cq_event(index) < 0) {
+      return -1;
+    }
     waitExternalEvent(index);
     return 0;
   }
 
   public native int wait_cq_event(int index);
-  private native void init(long Service);
+  private native int init(long Service);
   public native void finalize();
   private native void free();
   private long nativeHandle;

--- a/java/hpnl/src/main/java/com/intel/hpnl/core/CqThread.java
+++ b/java/hpnl/src/main/java/com/intel/hpnl/core/CqThread.java
@@ -11,7 +11,9 @@ public class CqThread extends Thread {
 
   public void run() {
     while (running.get()) {
-      cqService.wait_event(index);
+      if (this.cqService.wait_event(index) == -1) {
+        shutdown();
+      }
     }
   }
 

--- a/java/hpnl/src/main/java/com/intel/hpnl/core/EqThread.java
+++ b/java/hpnl/src/main/java/com/intel/hpnl/core/EqThread.java
@@ -3,15 +3,17 @@ package com.intel.hpnl.core;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class EqThread extends Thread {
-  public EqThread(EqService service_) {
-    this.service = service_;
+  public EqThread(EqService eqService) {
+    this.eqService = eqService;
     running.set(true);
   }
 
   public void run() {
-    while (running.get() || service.needReap()) {
-      this.service.wait_eq_event();
-      this.service.externalEvent();
+    while (running.get() || eqService.needReap()) {
+      if (this.eqService.wait_eq_event() == -1) {
+        shutdown();
+      }
+      this.eqService.externalEvent();
     }
   }
 
@@ -20,6 +22,6 @@ public class EqThread extends Thread {
     running.set(false); 
   }
 
-  private EqService service;
+  private EqService eqService;
   private final AtomicBoolean running = new AtomicBoolean(false);
 }

--- a/java/hpnl/src/test/java/com/intel/hpnl/pingpong/Client.java
+++ b/java/hpnl/src/test/java/com/intel/hpnl/pingpong/Client.java
@@ -20,8 +20,8 @@ public class Client {
     }
     byteBufferTmp.flip();
 
-    EqService eqService = new EqService("172.168.2.106", "123456", 1, BUFFER_NUM, false);
-    CqService cqService = new CqService(eqService, eqService.getNativeHandle());
+    EqService eqService = new EqService("172.168.2.106", "123456", 1, BUFFER_NUM, false).init();
+    CqService cqService = new CqService(eqService, eqService.getNativeHandle()).init();
 
     List<Connection> conList = new CopyOnWriteArrayList<Connection>();
 
@@ -35,8 +35,8 @@ public class Client {
 
     eqService.initBufferPool(BUFFER_NUM, BUFFER_SIZE, BUFFER_NUM);
 
-    cqService.start();
     eqService.start();
+    cqService.start();
 
     eqService.waitToConnected();
     System.out.println("connected, start to pingpong.");

--- a/java/hpnl/src/test/java/com/intel/hpnl/pingpong/Server.java
+++ b/java/hpnl/src/test/java/com/intel/hpnl/pingpong/Server.java
@@ -12,9 +12,9 @@ public class Server {
     final int BUFFER_SIZE = 65536;
     final int BUFFER_NUM = 32;
 
-    EqService eqService = new EqService("172.168.2.106", "123456", 3, BUFFER_NUM, true);
-    CqService cqService = new CqService(eqService, eqService.getNativeHandle());
-
+    EqService eqService = new EqService("172.168.2.106", "123456", 3, BUFFER_NUM, true).init();
+    CqService cqService = new CqService(eqService, eqService.getNativeHandle()).init();
+    
     List<Connection> conList = new ArrayList<Connection>();
 
     ConnectedCallback connectedCallback = new ConnectedCallback(conList, true);
@@ -24,9 +24,9 @@ public class Server {
 
     eqService.initBufferPool(BUFFER_NUM, BUFFER_SIZE, BUFFER_NUM);
 
-    cqService.start();
     eqService.start();
-
+    cqService.start();
+    
     cqService.join();
     eqService.shutdown();
     eqService.join();

--- a/java/hpnl/src/test/java/com/intel/hpnl/rma/Client.java
+++ b/java/hpnl/src/test/java/com/intel/hpnl/rma/Client.java
@@ -18,8 +18,8 @@ public class Client {
     byteBufferTmp.putChar('a');
     byteBufferTmp.flip();
 
-    EqService eqService = new EqService("172.168.2.106", "123456", 1, BUFFER_NUM, false);
-    CqService cqService = new CqService(eqService, eqService.getNativeHandle());
+    EqService eqService = new EqService("172.168.2.106", "123456", 1, BUFFER_NUM, false).init();
+    CqService cqService = new CqService(eqService, eqService.getNativeHandle()).init();
     RdmaBuffer buffer = eqService.getRmaBuffer(4096*1024);
 
     List<Connection> conList = new CopyOnWriteArrayList<Connection>();

--- a/java/hpnl/src/test/java/com/intel/hpnl/rma/Server.java
+++ b/java/hpnl/src/test/java/com/intel/hpnl/rma/Server.java
@@ -12,8 +12,8 @@ public class Server {
     final int BUFFER_SIZE = 65536;
     final int BUFFER_NUM = 128;
 
-    EqService eqService = new EqService("172.168.2.106", "123456", 1, BUFFER_NUM, true);
-    CqService cqService = new CqService(eqService, eqService.getNativeHandle());
+    EqService eqService = new EqService("172.168.2.106", "123456", 1, BUFFER_NUM, true).init();
+    CqService cqService = new CqService(eqService, eqService.getNativeHandle()).init();
 
     List<Connection> conList = new ArrayList<Connection>();
     

--- a/java/native/com_intel_hpnl_core_Connection.cc
+++ b/java/native/com_intel_hpnl_core_Connection.cc
@@ -15,7 +15,7 @@ static jfieldID _get_self_id(JNIEnv *env, jobject thisObj)
   return fidSelfPtr;
 }
 
-static  Connection*_get_self(JNIEnv *env, jobject thisObj)
+static Connection*_get_self(JNIEnv *env, jobject thisObj)
 {
   jlong selfPtr = env->GetLongField(thisObj, _get_self_id(env, thisObj));
   return *(Connection**)&selfPtr;
@@ -32,9 +32,9 @@ JNIEXPORT void JNICALL Java_com_intel_hpnl_core_Connection_recv(JNIEnv *env, job
   con->recv((char*)buffer, mid);
 }
 
-JNIEXPORT void JNICALL Java_com_intel_hpnl_core_Connection_send(JNIEnv *env, jobject thisObj, jint blockBufferSize, jint rdmaBufferId) {
+JNIEXPORT int JNICALL Java_com_intel_hpnl_core_Connection_send(JNIEnv *env, jobject thisObj, jint blockBufferSize, jint rdmaBufferId) {
   Connection *con = _get_self(env, thisObj); 
-  con->send(blockBufferSize, rdmaBufferId);
+  return con->send(blockBufferSize, rdmaBufferId);
 }
 
 JNIEXPORT int JNICALL Java_com_intel_hpnl_core_Connection_read(JNIEnv *env, jobject thisObj, jint rdmaBufferId, jint localOffset, jlong len, jlong remoteAddr, jlong remoteMr) {

--- a/java/native/com_intel_hpnl_core_Connection.h
+++ b/java/native/com_intel_hpnl_core_Connection.h
@@ -20,7 +20,7 @@ JNIEXPORT void JNICALL Java_com_intel_hpnl_core_Connection_recv
  * Method:    send
  * Signature: (Ljava/nio/ByteBuffer;II)V
  */
-JNIEXPORT void JNICALL Java_com_intel_hpnl_core_Connection_send
+JNIEXPORT int JNICALL Java_com_intel_hpnl_core_Connection_send
   (JNIEnv *, jobject, jint, jint);
 
 /*

--- a/java/native/com_intel_hpnl_core_CqService.h
+++ b/java/native/com_intel_hpnl_core_CqService.h
@@ -20,7 +20,7 @@ JNIEXPORT jint JNICALL Java_com_intel_hpnl_core_CqService_wait_1cq_1event
  * Method:    init
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL Java_com_intel_hpnl_core_CqService_init
+JNIEXPORT jint JNICALL Java_com_intel_hpnl_core_CqService_init
   (JNIEnv *, jobject, jlong);
 
 /*

--- a/java/native/com_intel_hpnl_core_EqService.h
+++ b/java/native/com_intel_hpnl_core_EqService.h
@@ -91,7 +91,7 @@ JNIEXPORT jlong JNICALL Java_com_intel_hpnl_core_EqService_get_1buffer_1address
  * Method:    init
  * Signature: (Ljava/lang/String;Ljava/lang/String;Z)V
  */
-JNIEXPORT void JNICALL Java_com_intel_hpnl_core_EqService_init
+JNIEXPORT jint JNICALL Java_com_intel_hpnl_core_EqService_init
   (JNIEnv *, jobject, jstring, jstring, jint, jint, jboolean);
 
 /*

--- a/src/core/FIConnection.cc
+++ b/src/core/FIConnection.cc
@@ -3,53 +3,14 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-FIConnection::FIConnection(FIStack *stack_, fid_fabric *fabric_, fi_info *info_, fid_domain *domain_, fid_cq* cq_, fid_wait *waitset_, BufMgr *recv_buf_mgr_, BufMgr *send_buf_mgr_, bool is_server, int buffer_num) : stack(stack_), info(info_), domain(domain_), conCq(cq_), recv_buf_mgr(recv_buf_mgr_), send_buf_mgr(send_buf_mgr_), waitset(waitset_), server(is_server), read_callback(NULL), send_callback(NULL), shutdown_callback(NULL) {
-  assert(!fi_endpoint(domain, info, &ep, NULL));
-  
-  struct fi_eq_attr eq_attr = {
-    .size = 0,
-    .flags = 0,
-    .wait_obj = FI_WAIT_UNSPEC,
-    .signaling_vector = 0,
-    .wait_set = NULL
-  };
-
-  if (fi_eq_open(fabric_, &eq_attr, &conEq, &eqHandle)) {
-    std::cout << "eq open error " << errno << std::endl; 
-  }
-  assert(!fi_ep_bind(ep, &conEq->fid, 0));
-
-  assert(!fi_ep_bind(ep, &conCq->fid, FI_TRANSMIT | FI_RECV));
-  
-  assert(!fi_enable(ep));
-  int size = 0;
-  while (size < buffer_num*2) {
-    fid_mr *mr;
-    Chunk *ck = recv_buf_mgr->get();
-    assert(ck->buffer);
-    assert(!fi_mr_reg(domain, ck->buffer, ck->capacity, FI_REMOTE_READ | FI_REMOTE_WRITE | FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL));
-    ck->con = this;
-    ck->mr = mr;
-    assert(!fi_recv(ep, ck->buffer, ck->capacity, fi_mr_desc(mr), 0, ck));
-    mr = NULL;
-    recv_buffers.push_back(ck);
-    size++;
-  }
-  size = 0;
-  while (size < buffer_num) {
-    fid_mr *mr;
-    Chunk *ck = send_buf_mgr->get();
-    assert(!fi_mr_reg(domain, ck->buffer, ck->capacity, FI_REMOTE_READ | FI_REMOTE_WRITE | FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL));
-    ck->con = this;
-    ck->mr = mr;
-    mr = NULL;
-    send_buffers.push_back(ck);
-    send_buffers_map.insert(std::pair<int, Chunk*>(ck->rdma_buffer_id, ck));
-    size++;
-  }
-
-  eqHandle.reset(new Handle(&conEq->fid, EQ_EVENT, conEq));
-}
+FIConnection::FIConnection(FIStack *stack_, fid_fabric *fabric_, 
+    fi_info *info_, fid_domain *domain_, fid_cq* cq_, 
+    fid_wait *waitset_, BufMgr *recv_buf_mgr_, 
+    BufMgr *send_buf_mgr_, bool is_server_, int buffer_num_) : 
+  stack(stack_), fabric(fabric_), info(info_), domain(domain_), ep(NULL),
+  conCq(cq_), conEq(NULL), recv_buf_mgr(recv_buf_mgr_), send_buf_mgr(send_buf_mgr_), 
+  waitset(waitset_), is_server(is_server_), buffer_num(buffer_num_), 
+  read_callback(NULL), send_callback(NULL), shutdown_callback(NULL) {}
 
 FIConnection::~FIConnection() {
   for (auto buffer: send_buffers_map) {
@@ -64,29 +25,131 @@ FIConnection::~FIConnection() {
     recv_buf_mgr->add(ck->rdma_buffer_id, ck);
   }
   shutdown();
-  fi_close(&ep->fid);
-  fi_close(&conEq->fid);
-  if (server) {
+  if (ep) {
+    fi_close(&ep->fid);
+    ep = nullptr;
+  }
+  if (conEq) {
+    fi_close(&conEq->fid);
+    conEq = nullptr;
+  }
+  if (is_server) {
     fi_freeinfo(info);
+    info = nullptr;
   }
 }
 
-void FIConnection::send(const char *buffer, int block_buffer_size, int rdma_buffer_id, int block_buffer_id, long seq) {
-  // TODO: get send buffer
+int FIConnection::init() {
+  int size = 0;
+  struct fi_eq_attr eq_attr = {
+    .size = 0,
+    .flags = 0,
+    .wait_obj = FI_WAIT_UNSPEC,
+    .signaling_vector = 0,
+    .wait_set = NULL
+  };
+
+  if (fi_endpoint(domain, info, &ep, NULL)) {
+    perror("fi_endpoint");
+    goto free_ep;
+  }
+
+  if (fi_eq_open(fabric, &eq_attr, &conEq, &eqHandle)) {
+    perror("fi_eq_open");
+    goto free_eq;
+  }
+  if (fi_ep_bind(ep, &conEq->fid, 0)) {
+    perror("fi_ep_bind");
+    goto free_eq;
+  }
+
+  if (fi_ep_bind(ep, &conCq->fid, FI_TRANSMIT | FI_RECV)) {
+    perror("fi_ep_bind");
+    goto free_eq;
+  }
+  
+  fi_enable(ep);
+  while (size < buffer_num*2) {
+    fid_mr *mr;
+    Chunk *ck = recv_buf_mgr->get();
+    if (fi_mr_reg(domain, ck->buffer, ck->capacity, FI_REMOTE_READ | FI_REMOTE_WRITE | FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL)) {
+      perror("fi_mr_reg");
+      goto free_recv_buf;
+    }
+    ck->con = this;
+    ck->mr = mr;
+    if (fi_recv(ep, ck->buffer, ck->capacity, fi_mr_desc(mr), 0, ck)) {
+      perror("fi_recv");
+      goto free_recv_buf;
+    }
+    mr = NULL;
+    recv_buffers.push_back(ck);
+    size++;
+  }
+  size = 0;
+  while (size < buffer_num) {
+    fid_mr *mr;
+    Chunk *ck = send_buf_mgr->get();
+    if (fi_mr_reg(domain, ck->buffer, ck->capacity, FI_REMOTE_READ | FI_REMOTE_WRITE | FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL)) {
+      perror("fi_mr_reg");
+      goto free_send_buf;
+    }
+    ck->con = this;
+    ck->mr = mr;
+    mr = NULL;
+    send_buffers.push_back(ck);
+    send_buffers_map.insert(std::pair<int, Chunk*>(ck->rdma_buffer_id, ck));
+    size++;
+  }
+
+  eqHandle.reset(new Handle(&conEq->fid, EQ_EVENT, conEq));
+  return 0;
+
+free_send_buf:
+  for (auto buffer: send_buffers_map) {
+    Chunk *ck = buffer.second;
+    fi_close(&((fid_mr*)ck->mr)->fid);
+    send_buf_mgr->add(ck->rdma_buffer_id, ck);
+  }
+free_recv_buf:
+  while (recv_buffers.size() > 0) {
+    Chunk *ck = recv_buffers.back();
+    fi_close(&((fid_mr*)ck->mr)->fid);
+    recv_buffers.pop_back();
+    recv_buf_mgr->add(ck->rdma_buffer_id, ck);
+  }
+free_eq:
+  if (conEq) {
+    fi_close(&conEq->fid);
+    conEq = nullptr;
+  }
+free_ep:
+  if (ep) {
+    fi_close(&ep->fid);
+    ep = nullptr;
+  }
+
+  return -1;
+}
+
+int FIConnection::send(const char *buffer, int block_buffer_size, int rdma_buffer_id, int block_buffer_id, long seq) {
   Chunk *ck = send_buffers.back();
-  assert(ck->buffer);
   send_buffers.pop_back();
   memcpy(ck->buffer, buffer, block_buffer_size);
   if (fi_send(ep, ck->buffer, block_buffer_size, fi_mr_desc((fid_mr*)ck->mr), 0, ck)) {
-    // TODO: error handler
+    perror("fi_send");
+    return -1;
   }
+  return 0;
 }
 
-void FIConnection::send(int block_buffer_size, int rdma_buffer_id) {
+int FIConnection::send(int block_buffer_size, int rdma_buffer_id) {
   Chunk *ck = send_buffers_map[rdma_buffer_id];
   if (fi_send(ep, ck->buffer, block_buffer_size, fi_mr_desc((fid_mr*)ck->mr), 0, ck)) {
-    // TODO: error handler
+    perror("fi_send");
+    return -1;
   }
+  return 0;
 }
 
 void FIConnection::recv(char *buffer, int buffer_size) {
@@ -99,16 +162,30 @@ int FIConnection::read(int rdma_buffer_id, int local_offset, uint64_t len, uint6
   return fi_read(ep, (char*)ck->buffer+local_offset, len, fi_mr_desc((fid_mr*)ck->mr), 0, remote_addr, remote_key, ck);
 }
 
-void FIConnection::connect() {
-  assert(!fi_connect(ep, info->dest_addr, NULL, 0));
+int FIConnection::connect() {
+  int res = fi_connect(ep, info->dest_addr, NULL, 0);
+  if (res) {
+    if (res == EAGAIN) {
+      return EAGAIN;
+    } else {
+      perror("fi_connect");
+      return -1;
+    }
+  }
+  return 0;
 }
 
-void FIConnection::accept() {
-  assert(!fi_accept(ep, NULL, 0));
+int FIConnection::accept() {
+  if (fi_accept(ep, NULL, 0)) {
+    perror("fi_accept");
+    return -1;
+  }
+  return 0;
 }
 
 void FIConnection::shutdown() {
-  assert(!fi_shutdown(ep, 0));
+  if (fi_shutdown(ep, 0))
+    perror("fi_shutdown");
 }
 
 void FIConnection::init_addr() {
@@ -169,12 +246,15 @@ fid* FIConnection::get_fid() {
   return &conEq->fid;
 }
 
-void FIConnection::activate_chunk(Chunk *ck) {
+int FIConnection::activate_chunk(Chunk *ck) {
   ck->con = this;
-  fi_recv(ep, ck->buffer, ck->capacity, fi_mr_desc((fid_mr*)ck->mr), 0, ck);
+  if (fi_recv(ep, ck->buffer, ck->capacity, fi_mr_desc((fid_mr*)ck->mr), 0, ck)) {
+    perror("fi_recv");
+    return -1; 
+  }
+  return 0;
 }
 
 HandlePtr FIConnection::get_eqhandle() {
   return eqHandle;
 }
-

--- a/src/demultiplexer/EQEventDemultiplexer.cc
+++ b/src/demultiplexer/EQEventDemultiplexer.cc
@@ -27,14 +27,11 @@ int EQEventDemultiplexer::wait_event(std::map<HandlePtr, EventHandlerPtr> &event
     } else {
       entry.fid = handlePtr->get_fid();
       if (event == FI_CONNREQ) {
-        std::cout << "FI_CONNREQ" << std::endl;
         eventMap[handlePtr]->handle_event(ACCEPT_EVENT, &entry); 
       } else if (event == FI_CONNECTED)  {
-        std::cout << "FI_CONNECTED" << std::endl;
         eventMap[handlePtr]->handle_event(CONNECTED_EVENT, &entry);
         con_inflight++;
       } else if (event == FI_SHUTDOWN) {
-        std::cout << "FI_SHUTDOWN" << std::endl;
         eventMap[handlePtr]->handle_event(CLOSE_EVENT, &entry); 
         con_inflight--;
         if (con_inflight == 0) {

--- a/src/demultiplexer/Reactor.cc
+++ b/src/demultiplexer/Reactor.cc
@@ -17,7 +17,6 @@ int Reactor::eq_service() {
 }
 
 int Reactor::cq_service(int index) {
-  std::cout << "index " << index << std::endl;
   return cqDemultiplexer[index]->wait_event();
 }
 

--- a/src/external_demultiplexer/CQExternalDemultiplexer.cc
+++ b/src/external_demultiplexer/CQExternalDemultiplexer.cc
@@ -1,25 +1,29 @@
 #include "HPNL/CQExternalDemultiplexer.h"
 
-CQExternalDemultiplexer::CQExternalDemultiplexer(FIStack *stack, fid_cq *cq_) : cq(cq_) {
-  fabric = stack->get_fabric();
-  epfd = epoll_create1(0);
-  memset((void*)&event, 0, sizeof event);
-  int ret = fi_control(&cq->fid, FI_GETWAIT, (void*)&fd);
-  if (ret) {
-    std::cout << "fi_controll error." << std::endl; 
-  }
-  event.events = EPOLLIN;
-  event.data.ptr = &cq->fid;
-  ret = epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event);
-  if (ret) {
-    std::cout << "epoll add error." << std::endl; 
-  }
-  start = 0;
-  end = 0;
-}
+CQExternalDemultiplexer::CQExternalDemultiplexer(FIStack *stack_, fid_cq *cq_) : stack(stack_), cq(cq_), start(0), end(0) {}
 
 CQExternalDemultiplexer::~CQExternalDemultiplexer() {
   close(epfd);
+}
+
+int CQExternalDemultiplexer::init() {
+  fabric = stack->get_fabric();
+  if ((epfd = epoll_create1(0)) == -1) {
+    perror("epoll_create1");
+    return -1;
+  }
+  memset((void*)&event, 0, sizeof event);
+  if (fi_control(&cq->fid, FI_GETWAIT, (void*)&fd)) {
+    perror("fi_control");
+    return -1;
+  }
+  event.events = EPOLLIN;
+  event.data.ptr = &cq->fid;
+  if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event) < 0) {
+    perror("epoll_ctl");
+    return -1;
+  }
+  return 0;
 }
 
 int CQExternalDemultiplexer::wait_event(fid_eq** eq, int* rdma_buffer_id, int* block_buffer_size) {
@@ -29,12 +33,16 @@ int CQExternalDemultiplexer::wait_event(fid_eq** eq, int* rdma_buffer_id, int* b
   if (end - start >= 200) {
     if (fi_trywait(fabric, fids, 1) == FI_SUCCESS) {
       int epoll_ret = epoll_wait(epfd, &event, 1, 200);
-      if (epoll_ret < 0) {
-        std::cout << "error" << std::endl;
-        return epoll_ret;
-      }
-      if (event.data.ptr != (void*)&cq->fid) {
-        std::cout << "got error event" << std::endl;
+      if (epoll_ret > 0) {
+        assert(event.data.ptr == (void*)&cq->fid);
+      } else if (epoll_ret < 0) {
+        if (errno != EINTR) {
+          perror("epoll_wait");
+          return -1;
+        }
+        return 0;
+      } else {
+        return 0; 
       }
     }
     start = std::chrono::high_resolution_clock::now().time_since_epoch() / std::chrono::microseconds(1);
@@ -44,10 +52,13 @@ int CQExternalDemultiplexer::wait_event(fid_eq** eq, int* rdma_buffer_id, int* b
     ret = fi_cq_read(cq, &entry, 1);
     if (ret == -FI_EAVAIL) {
       fi_cq_err_entry err_entry;
-      fi_cq_readerr(cq, &err_entry, entry.flags); 
-      std::cout << "error" << std::endl;
+      fi_cq_readerr(cq, &err_entry, entry.flags);
       end = std::chrono::high_resolution_clock::now().time_since_epoch() / std::chrono::microseconds(1);
-      return -1;
+      perror("fi_cq_read");
+      if (err_entry.err == FI_EOVERRUN) {
+        return -1;
+      }
+      return 0;
     } else if (ret == -FI_EAGAIN) {
       end = std::chrono::high_resolution_clock::now().time_since_epoch() / std::chrono::microseconds(1);
       return 0;

--- a/src/service/Service.cc
+++ b/src/service/Service.cc
@@ -28,13 +28,11 @@ Service::~Service() {
 
 void Service::run(int worker_num, int buffer_num) {
   if (is_server) {
-    std::cout << "server " << worker_num << std::endl;
     stack = new FIStack(ip, port, FI_SOURCE, worker_num, buffer_num);
   } else {
-    std::cout << "client " << worker_num << std::endl;
     stack = new FIStack(ip, port, 0, 1, buffer_num);
   }
-  
+  stack->init();
   eq_demulti_plexer = new EQEventDemultiplexer();
   for (int i = 0; i < worker_num; i++) {
     cq_demulti_plexer[i] = new CQEventDemultiplexer(stack, i);
@@ -47,7 +45,6 @@ void Service::run(int worker_num, int buffer_num) {
     HandlePtr eqHandle;
     eqHandle = stack->bind();
     stack->listen();
-    std::cout << "listen" << std::endl;
 
     EventHandlerPtr handler(new EQHandler(stack, reactor, eqHandle));
     acceptRequestCallback = new AcceptRequestCallback(this);
@@ -62,7 +59,6 @@ void Service::run(int worker_num, int buffer_num) {
     HandlePtr eqHandle[worker_num];
     for (int i = 0; i< worker_num; i++) {
       eqHandle[i] = stack->connect(recvBufMgr, sendBufMgr);
-      std::cout << "connect" << std::endl;
 
       EventHandlerPtr handler(new EQHandler(stack, reactor, eqHandle[i]));
       acceptRequestCallback = new AcceptRequestCallback(this);

--- a/test/ping-pong/client.cc
+++ b/test/ping-pong/client.cc
@@ -36,7 +36,6 @@ class ConnectedCallback : public Callback {
       char* buffer = (char*)std::malloc(SIZE);
       memset(buffer, '0', SIZE);
       con->send(buffer, SIZE, SIZE, 0, 0);
-      std::cout << "send." << std::endl;
       std::free(buffer);
     }
   private:


### PR DESCRIPTION
Basically, this patch wants to add more error handlers for HPNL.

For Java API:
1.  Decoupled the EqService/CqService initiation from its constructor. Return 0 on success and return -1 error. The error log should be written into the standard output stream.
2.  Other APIs like send/getSendBuffer/getRecvBuffer/takeSendBuffer also has return values to indicate the error or exception.
3.  Just the errors caused by epoll_wait and fi_cq_read/fi_eq_read will stop EqThread/CqThread, other errors will not stop them. The error log also can be found from the standard output stream.

Signed-off-by: Haodong Tang <haodong.tang@intel.com>