### PR TITLE
Can optionally use LibFabric and FlatBuffers install in custom directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_COMPILER /usr/bin/g++)
 
+# include custom FindXXX.cmake path
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/)
+
 if(UNIX AND NOT APPLE)
   set(LINUX TRUE)
 endif()
@@ -36,6 +39,12 @@ endif()
 find_package(Boost REQUIRED COMPONENTS system)
 if(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
+endif()
+
+# search libfabric
+find_package(LibFabric REQUIRED)
+if (LIBFABRIC_FOUND)
+  include_directories(${LIBFABRIC_INCLUDE_DIR})
 endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/src)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ cmake -DWITH_PSM2=ON ..      // for Omni-Path Protocol
 make && make install
 ```
 
+If you install LibFabric or FlatBuffers in a custom directory you can point them using :
+```shell
+cmake -DLIBFABRIC_PREFIX=..... -DFLATBUFFERS_PREFIX=.....
+```
+
 ### Build for Java
 The HPNL Java API comes with HPNL C/C++ shared library, the native code won't be included without explicit cmake option.
 

--- a/cmake/FindFlatBuffers.cmake
+++ b/cmake/FindFlatBuffers.cmake
@@ -1,0 +1,30 @@
+# Try to find Flat Buffers (https://github.com/google/flatbuffers)
+# Once done this will define
+#  FLATBUFFERS_FOUND       - System has Flat Buffers
+#  FLATBUFFERS_INCLUDE_DIR - The Flat Buffers include directories
+#  FLATBUFFERS_LIBRARY     - The libraries needed to use Flat Buffers
+
+# searhc prefix path
+set(FLATBUFFERS_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE STRING "Help cmake to find Flat Buffers library (https://github.com/google/flatbuffers).")
+
+# check include
+find_path(FLATBUFFERS_INCLUDE_DIR rdma/fabric.h
+	HINTS ${FLATBUFFERS_PREFIX}/include)
+
+# check lib
+find_library(FLATBUFFERS_LIBRARY NAMES fabric
+	HINTS ${FLATBUFFERS_PREFIX}/lib)
+
+# setup found
+if (FLATBUFFERS_LIBRARY AND FLATBUFFERS_INCLUDE_DIR)
+	set(FLATBUFFERS_FOUND ON)
+endif()
+
+# handle QUIET/REQUIRED
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set FLATBUFFERS_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(FlatBuffers DEFAULT_MSG FLATBUFFERS_LIBRARY FLATBUFFERS_INCLUDE_DIR)
+
+# Hide internal variables
+mark_as_advanced(FLATBUFFERS_INCLUDE_DIR FLATBUFFERS_LIBRARY FLATBUFFERS_FOUND)

--- a/cmake/FindLibFabric.cmake
+++ b/cmake/FindLibFabric.cmake
@@ -1,0 +1,30 @@
+# Try to find LibFabric (https://github.com/ofiwg/libfabric)
+# Once done this will define
+#  LIBFABRIC_FOUND       - System has LibFabric
+#  LIBFABRIC_INCLUDE_DIR - The LibFabric include directories
+#  LIBFABRIC_LIBRARY     - The libraries needed to use LibFabric
+
+# searhc prefix path
+set(LIBFABRIC_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE STRING "Help cmake to find LibFabric library (https://github.com/ofiwg/libfabric).")
+
+# check include
+find_path(LIBFABRIC_INCLUDE_DIR rdma/fabric.h
+	HINTS ${LIBFABRIC_PREFIX}/include)
+
+# check lib
+find_library(LIBFABRIC_LIBRARY NAMES fabric
+	HINTS ${LIBFABRIC_PREFIX}/lib)
+
+# setup found
+if (LIBFABRIC_LIBRARY AND LIBFABRIC_INCLUDE_DIR)
+	set(LIBFABRIC_FOUND ON)
+endif()
+
+# handle QUIET/REQUIRED
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LIBFABRIC_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(LibFabric DEFAULT_MSG LIBFABRIC_LIBRARY LIBFABRIC_INCLUDE_DIR)
+
+# Hide internal variables
+mark_as_advanced(LIBFABRIC_INCLUDE_DIR LIBFABRIC_LIBRARY LIBFABRIC_FOUND)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -45,16 +45,19 @@ set_target_properties(rdm_client
 
 option(WITH_RMA_TEST "enable remote memory access test" OFF)
 if(WITH_RMA_TEST)
+  find_package(FlatBuffers REQUIRED)
+  include_directories(${FLATBUFFERS_INCLUDE_DIR})
+
   set(RMA_TEST ${PROJECT_SOURCE_DIR}/examples/rma)
 
   add_executable(rma_server ${RMA_TEST}/server.cc)
-  target_link_libraries(rma_server hpnl flatbuffers)
+  target_link_libraries(rma_server hpnl ${FLATBUFFER_LIBRARY})
   set_target_properties(rma_server
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/rma")
 
   add_executable(rma_client ${RMA_TEST}/client.cc)
-  target_link_libraries(rma_client hpnl flatbuffers)
+  target_link_libraries(rma_client hpnl ${FLATBUFFER_LIBRARY})
   set_target_properties(rma_client
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/rma")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,27 +16,27 @@
 # under the License.
 
 add_executable(core_test ${PROJECT_SOURCE_DIR}/src/test/CoreTest.cc ${CORE_FILE} ${CHUNK_FILE})
-target_link_libraries(core_test fabric boost_system)
+target_link_libraries(core_test ${LIBFABRIC_LIBRARY} boost_system)
 set_target_properties(core_test
   PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/test")
 
 add_executable(service_test ${PROJECT_SOURCE_DIR}/src/test/ServiceTest.cc
         ${CORE_FILE} ${SERVICE_FILE} ${DEMULTIPLEXER_FILE} ${CHUNK_FILE})
-target_link_libraries(service_test fabric boost_system)
+target_link_libraries(service_test ${LIBFABRIC_LIBRARY} boost_system)
 set_target_properties(service_test
   PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/test")
 
 add_executable(chunk_test ${PROJECT_SOURCE_DIR}/src/test/ChunkPoolTest.cc ${CHUNK_FILE} chunk/ExternalChunkMgr.cc)
-target_link_libraries(chunk_test fabric boost_system)
+target_link_libraries(chunk_test ${LIBFABRIC_LIBRARY} boost_system)
 set_target_properties(chunk_test
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/test")
 
 if(NOT ${SUPPORT_JAVA})
   add_library(hpnl SHARED ${DEMULTIPLEXER_FILE} ${CORE_FILE} ${SERVICE_FILE} ${EXTERNAL_DEMULTIPLEXER_FILE} ${EXTERNAL_SERVICE_FILE} ${CHUNK_FILE})
-  target_link_libraries(hpnl fabric boost_system)
+  target_link_libraries(hpnl ${LIBFABRIC_LIBRARY} boost_system)
   set_target_properties(hpnl PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 
   set(CMAKE_INSTALL_PREFIX "/usr/local")


### PR DESCRIPTION
Current cmake scripts hard code usage of libfabric and flatbuffers considering they are installed into /usr or /usr/local paths of the system.

On a system we are no admin on we might want to install them in `$HOME/usr` or other.

With the given patch we can search them by using :

```shell
cmake .. -DLIBFABRIC_PREFIX=$HOME/usr -DFLATBUFFERS_PREFIX=$HOME/usr
```

Cmake also complain directly if it cannot find the libs.

**Remark**
Some people use `WITH_LIBFABRIC=$HOME/usr` semantic, what did you prefer ? (personally I use `XXXX_PREFIX` on my projects so it does not missmatch with the ON/OFF usage.